### PR TITLE
Improve responsive layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,9 +71,9 @@
   </div>
   <div class="right-column">
     <h2>Configuration Preview</h2>
-    <pre id="current-config">Select a folder to load configuration files.</pre>
+    <pre id="current-config" class="config-view">Select a folder to load configuration files.</pre>
     <h2>Changes</h2>
-    <pre id="diff"></pre>
+    <pre id="diff" class="config-view"></pre>
   </div>
   </div>
   </main>

--- a/style.css
+++ b/style.css
@@ -16,8 +16,13 @@
   --button-text: #ffffff;
 }
 
+/* Global resets */
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', Tahoma, sans-serif;
   margin: 0;
   padding: 0 1em;
   line-height: 1.5;
@@ -26,7 +31,7 @@ body {
 }
 
 main {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 2em auto;
 }
 
@@ -60,12 +65,16 @@ ol > li {
   background: var(--secondary-bg);
 }
 
-pre {
+
+.config-view {
   background: var(--secondary-bg);
   padding: 1em;
   overflow: auto;
   border: 1px solid var(--border-color);
+  border-radius: 4px;
   font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 button,
@@ -130,27 +139,31 @@ button:hover,
 /* Two-column layout */
 .columns {
   display: flex;
-  gap: 1em;
+  flex-wrap: nowrap;
+  gap: 1.5em;
   align-items: flex-start;
 }
 
 .left-column {
   flex: 1;
+  min-width: 0;
 }
 
 .right-column {
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 1em;
   border: 1px solid var(--border-color);
   background: var(--secondary-bg);
   padding: 1em;
+  box-shadow: 0 0 5px rgba(0,0,0,0.1);
   max-height: 80vh;
   overflow: auto;
 }
 
-.right-column pre {
+.right-column .config-view {
   flex: 1;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- refine two-column layout with flexbox tweaks
- make configuration previews use new `.config-view` styling
- bump maximum main width for larger screens
- modernize fonts and add global box-sizing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68747d56b3708322bd8415a7970ef22c