### PR TITLE
Support user config folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This project provides a static web page to help you update your Unreal Tournamen
 ## Usage
 
 1. Open `index.html` in a modern browser or visit the GitHub Pages site after deployment.
-2. Select your local UT3 installation folder when prompted. This folder must contain the
-   `UTGame` subfolder with configuration files like `UTEngine.ini` and `UTGame.ini`.
+2. Select your local UT3 **installation folder** or your **user config folder** when prompted.
+   The app automatically detects `UTEngine.ini`/`UTGame.ini` or `DefaultEngine.ini`/`DefaultUI.ini`
+   and updates whichever files are present.
    Example paths:
-   - **Windows Retail:** `C:\Program Files (x86)\Unreal Tournament 3`
-   - **Steam (Windows):** `C:\Program Files (x86)\Steam\steamapps\common\Unreal Tournament 3`
-   - **Linux (Steam/Proton):** `/steamapps/compatdata/13210/pfx/drive_c/users/steamuser/My Documents/My Games/Unreal Tournament 3`
+   - **Game Install (Windows):** `C:\Program Files (x86)\Unreal Tournament 3`
+   - **Game Install (Steam):** `C:\Program Files (x86)\Steam\steamapps\common\Unreal Tournament 3`
+   - **User Config (Windows):** `%USERPROFILE%\Documents\My Games\Unreal Tournament 3`
+   - **User Config (Steam/Proton):** `/steamapps/compatdata/13230/pfx/drive_c/users/steamuser/My Documents/My Games/Unreal Tournament 3`
 3. Review the detected configuration.
 4. Enter the new master server URL and port, choose whether to advertise the server, then apply the changes.
 5. Download the modified INI files and replace them in your UT3 install (back up the originals first).

--- a/index.html
+++ b/index.html
@@ -21,15 +21,16 @@
     <li>
       <h2>1. Select game folder</h2>
       <p id="folder-help">
-        Please select your <strong>Unreal Tournament 3</strong> installation or config folder. This folder must contain the
-        <code>UTGame</code> subfolder with configuration files like <code>UTEngine.ini</code> and
-        <code>UTGame.ini</code>. <br>
+        Select either your <strong>Unreal Tournament 3</strong> game installation folder (with default configs)
+        or your user config folder (with active game configs). The app will adjust whichever files it finds.
+        <br>
         <em>DefaultEngine.ini</em> and <em>DefaultUI.ini</em> will also be updated if present.
       </p>
       <ul class="examples">
-        <li><strong>Windows Retail:</strong>&nbsp;<code>C:\Program Files (x86)\Unreal Tournament 3</code></li>
-        <li><strong>Steam (Windows):</strong>&nbsp;<code>C:\Program Files (x86)\Steam\steamapps\common\Unreal Tournament 3</code></li>
-        <li><strong>Linux (Steam/Proton):</strong>&nbsp;<code>/steamapps/compatdata/13210/pfx/drive_c/users/steamuser/My Documents/My Games/Unreal Tournament 3</code></li>
+        <li><strong>Game Install (Windows):</strong>&nbsp;<code>C:\Program Files (x86)\Unreal Tournament 3</code></li>
+        <li><strong>Game Install (Steam):</strong>&nbsp;<code>C:\Program Files (x86)\Steam\steamapps\common\Unreal Tournament 3</code></li>
+        <li><strong>User Config (Windows):</strong>&nbsp;<code>%USERPROFILE%\Documents\My Games\Unreal Tournament 3</code></li>
+        <li><strong>User Config (Steam/Proton):</strong>&nbsp;<code>/steamapps/compatdata/13230/pfx/drive_c/users/steamuser/My Documents/My Games/Unreal Tournament 3</code></li>
       </ul>
       <button id="select-folder">Select Folder</button>
       <input type="file" id="folder-input" webkitdirectory directory multiple style="display:none;" />

--- a/script.js
+++ b/script.js
@@ -82,10 +82,12 @@ async function handleDirectory(dirHandle) {
 
   await traverse(dirHandle, '');
 
-  if (fileHandles['UTEngine.ini'] && fileHandles['UTGame.ini']) {
-    setFeedback('Success: Valid UT3 installation detected. Configuration files loaded.', 'success');
+  const hasActive = fileHandles['UTEngine.ini'] && fileHandles['UTGame.ini'];
+  const hasDefault = fileHandles['DefaultEngine.ini'] && fileHandles['DefaultUI.ini'];
+  if (hasActive || hasDefault) {
+    setFeedback('Success: UT3 configuration files loaded.', 'success');
   } else {
-    setFeedback('Error: The selected folder does not appear to contain the required UT3 configuration files. Please make sure you selected the correct game folder.', 'error');
+    setFeedback('Error: No UT3 configuration files were found. Please select your game install or user config folder.', 'error');
   }
   if (Object.keys(fileHandles).length === 0) {
     currentConfigPre.textContent = 'No config files found.';
@@ -131,10 +133,12 @@ folderInput.addEventListener('change', async (e) => {
     .map(([name, txt]) => `-- ${name} --\n${txt}`)
     .join('\n');
   currentConfigPre.textContent = combined || 'No config files found.';
-  if (fileHandles['UTEngine.ini'] && fileHandles['UTGame.ini']) {
-    setFeedback('Success: Valid UT3 installation detected. Configuration files loaded.', 'success');
+  const hasActive = fileHandles['UTEngine.ini'] && fileHandles['UTGame.ini'];
+  const hasDefault = fileHandles['DefaultEngine.ini'] && fileHandles['DefaultUI.ini'];
+  if (hasActive || hasDefault) {
+    setFeedback('Success: UT3 configuration files loaded.', 'success');
   } else {
-    setFeedback('Error: The selected folder does not contain the required UT3 configuration files. Please make sure you selected the correct game folder.', 'error');
+    setFeedback('Error: No UT3 configuration files were found. Please select your game install or user config folder.', 'error');
   }
   updateFilesList();
 });


### PR DESCRIPTION
## Summary
- detect either game install configs or user config folder
- give clearer instructions and extra examples for Windows and Proton paths
- document new folder options in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874842c95e083228484d79ee9fc9404